### PR TITLE
Add `trainer_class.py` file to the repo

### DIFF
--- a/nnunet/README.md
+++ b/nnunet/README.md
@@ -44,3 +44,8 @@ CUDA_VISIBLE_DEVICES=1 nnUNetv2_predict -i PATH_imagesTs -o OUTPUT_PATH -d XXX -
 python evaluation/evaluate_predictions.py -pred-folder PRED_PATH -label-folder PATH_labelsTs  -image-folder PATH_imagesTs -conversion-dict PATH_conversion_dict.json -output-folder PATH_OUTPUT
 python evaluation/plot_performance.py --pred-dir-path PRED_PATH  --data-json-path MSD_PATH --split test
 ```
+
+## Trainer class
+
+The `trainer_class.py` contains the nnUNet trainer used for training the model associated to the release https://github.com/ivadomed/ms-lesion-agnostic/releases/tag/r20250909
+It is also stored in the model_fold0.zip so that SCT can use it when performing inference with this specific model. 

--- a/nnunet/trainer_class.py
+++ b/nnunet/trainer_class.py
@@ -1,0 +1,12 @@
+import torch
+from nnunetv2.training.nnUNetTrainer.variants.loss.nnUNetTrainerDiceLoss import nnUNetTrainerDiceCELoss_noSmooth
+
+class nnUNetTrainerDiceCELoss_noSmooth_4000epochs_fromScratch(nnUNetTrainerDiceCELoss_noSmooth):
+    def __init__(self, plans: dict, configuration: str, fold: int, dataset_json: dict,
+                 device: torch.device = torch.device('cuda')):
+        super().__init__(plans, configuration, fold, dataset_json, device)
+        self.num_epochs = 4000
+
+# using a standardized function name so that SCT can import the class
+def get_trainer_class():
+   return nnUNetTrainerDiceCELoss_noSmooth_4000epochs_fromScratch


### PR DESCRIPTION
I added the `trainer_class.py` file related to the training of the model in this release: https://github.com/ivadomed/ms-lesion-agnostic/releases/tag/r20250909

It is also stored in the model_fold.zip file to be used by SCT when running inference with this model
