### PR TITLE
Retraining of the model on WMn data

### DIFF
--- a/dataset_aggregation/add_wnn_data_to_existing_msd.py
+++ b/dataset_aggregation/add_wnn_data_to_existing_msd.py
@@ -1,0 +1,211 @@
+"""
+This script adds WMn data (already registered in the conversion dict) to an existing
+MSD-style dataset JSON. It reads image/label pairs from the conversion dict whose
+nnUNet destination path contains 'WMn', infers the required metadata fields
+(contrast, site, acquisition, resolution, dimension, nb_lesions, total_lesion_volume),
+and appends the entries to the appropriate split (train / test) in the dataset JSON.
+
+Arguments:
+    --dataset       Path to the existing MSD dataset JSON
+    --conv-dict     Path to the conversion dict JSON
+    --path-wmn      Root path to the WMn data directory (used to load NIfTI files)
+    --output        Path for the updated dataset JSON output
+
+Example:
+    python add_wmn_to_msd_dataset.py \\
+        --dataset dataset_2025-04-15_seed42.json \\
+        --conv-dict conversion_dict.json \\
+        --path-wmn /home/plbenveniste/net/ms-lesion-agnostic/202604_train_WMn_model/nnunet_data/WMn_data \\
+        --output dataset_2025-04-15_seed42_wmn.json
+
+Pierre-Louis Benveniste
+"""
+
+import json
+import argparse
+import os
+from pathlib import Path
+
+import nibabel as nib
+import numpy as np
+import skimage.measure
+from loguru import logger
+from tqdm import tqdm
+
+
+# ---------------------------------------------------------------------------
+# Helpers (mirrors the logic in 1_create_msd_data.py)
+# ---------------------------------------------------------------------------
+
+def count_lesion(label_file):
+    """Return (total_lesion_volume_mm3, nb_lesions) for a NIfTI label file."""
+    label = nib.load(label_file)
+    label_data = label.get_fdata()
+    resolution = label.header.get_zooms()
+    total_volume = float(np.sum(label_data) * np.prod(resolution))
+    _, nb_lesions = skimage.measure.label(label_data, connectivity=2, return_num=True)
+    return total_volume, int(nb_lesions)
+
+
+def get_acquisition_resolution_and_dimension(image_path):
+    """Return (acquisition_str, resolution_list, dimension_list) for a NIfTI image."""
+    img = nib.load(str(image_path))
+    header = img.header
+    pixdim = np.array(header.get_zooms()[:3], dtype=float)
+    shape = np.array(img.shape[:3], dtype=int)
+
+    acquisition = '3D_sag'  # WMn images are always 3D sagittal acquisitions, so we hardcode this value.
+
+    return acquisition, pixdim.tolist(), shape.tolist()
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def get_parser():
+    parser = argparse.ArgumentParser(
+        description='Add WMn entries from a conversion dict to an MSD dataset JSON.'
+    )
+    parser.add_argument('--dataset',   required=True, type=str,
+                        help='Path to the existing MSD dataset JSON')
+    parser.add_argument('--conv-dict', required=True, type=str,
+                        help='Path to the conversion dict JSON')
+    parser.add_argument('--output',    required=True, type=str,
+                        help='Output path for the updated dataset JSON')
+    return parser
+
+
+def main():
+    parser = get_parser()
+    args = parser.parse_args()
+
+    # ------------------------------------------------------------------
+    # Load inputs
+    # ------------------------------------------------------------------
+    logger.info(f"Loading dataset JSON from {args.dataset}")
+    with open(args.dataset, 'r') as f:
+        dataset = json.load(f)
+
+    logger.info(f"Loading conversion dict from {args.conv_dict}")
+    with open(args.conv_dict, 'r') as f:
+        conv_dict = json.load(f)
+
+    # ------------------------------------------------------------------
+    # Extract WMn image→label pairs from the conversion dict
+    # The dict alternates: image_src → image_dst, label_src → label_dst
+    # We identify image entries by their nnUNet destination containing
+    # '_0000.nii.gz' (channel suffix), and labels by lacking it.
+    # We also determine train vs test from imagesTr / imagesTs.
+    # ------------------------------------------------------------------
+
+    wmn_pairs = {}   # nnunet_id → {'image': src, 'label': src, 'split': 'train'|'test'}
+
+    for src_path, dst_path in conv_dict.items():
+        # Only process WMn entries
+        if 'WMn' not in src_path:
+            continue
+
+        # Determine nnUNet case ID from destination filename
+        dst_name = Path(dst_path).stem.replace('.nii', '')  # e.g. msLesionAgnostic_001_0000
+        is_image = dst_name.endswith('_0000')
+        case_id = dst_name.replace('_0000', '')             # e.g. msLesionAgnostic_001
+
+        if case_id not in wmn_pairs:
+            wmn_pairs[case_id] = {'image': None, 'label': None, 'split': None}
+
+        if is_image:
+            wmn_pairs[case_id]['image'] = src_path
+            wmn_pairs[case_id]['split'] = 'train' if 'imagesTr' in dst_path else 'test'
+        else:
+            wmn_pairs[case_id]['label'] = src_path
+
+    logger.info(f"Found {len(wmn_pairs)} WMn entries in the conversion dict")
+
+    # ------------------------------------------------------------------
+    # Build MSD-style records
+    # ------------------------------------------------------------------
+    train_entries = []
+    test_entries  = []
+    skipped       = 0
+
+    for case_id, pair in tqdm(sorted(wmn_pairs.items()), desc="Processing WMn entries"):
+        image_path = pair['image']
+        label_path = pair['label']
+        split      = pair['split']
+
+        if image_path is None or label_path is None:
+            logger.warning(f"Incomplete pair for {case_id}, skipping")
+            skipped += 1
+            continue
+
+        if not os.path.exists(image_path):
+            logger.warning(f"Image not found on disk: {image_path}")
+            skipped += 1
+            continue
+
+        if not os.path.exists(label_path):
+            logger.warning(f"Label not found on disk: {label_path}")
+            skipped += 1
+            continue
+
+        try:
+            total_lesion_volume, nb_lesions = count_lesion(label_path)
+            acquisition, resolution, dimension = get_acquisition_resolution_and_dimension(image_path)
+        except Exception as e:
+            logger.warning(f"Failed to read NIfTI for {case_id}: {e}")
+            skipped += 1
+            continue
+
+        entry = {
+            "image":               image_path,
+            "label":               label_path,
+            "site":                "bordeaux",  # WMn data was acquired at Bordeaux, so we hardcode this value.
+            "contrast":            "WMn",       # WMn data is always acquired with the WMn contrast, so we hardcode this value.
+            "acquisition":         acquisition,
+            "resolution":          resolution,
+            "dimension":           dimension,
+            "nb_lesions":          nb_lesions,
+            "total_lesion_volume": total_lesion_volume,
+        }
+
+        if split == 'train':
+            train_entries.append(entry)
+        else:
+            test_entries.append(entry)
+
+    logger.info(f"WMn entries to add — train: {len(train_entries)}, test: {len(test_entries)}, skipped: {skipped}")
+
+    # ------------------------------------------------------------------
+    # Inject into dataset
+    # ------------------------------------------------------------------
+    dataset.setdefault('train', []).extend(train_entries)
+    dataset.setdefault('test',  []).extend(test_entries)
+
+    # Update counts
+    dataset['numTraining'] = len(dataset['train'])
+    dataset['numTest']     = len(dataset['test'])
+
+    # Update contrast counts
+    dataset.setdefault('contrasts', {})
+    for entry in train_entries + test_entries:
+        contrast = entry['contrast']
+        dataset['contrasts'][contrast] = dataset['contrasts'].get(contrast, 0) + 1
+
+    # ------------------------------------------------------------------
+    # Save
+    # ------------------------------------------------------------------
+    output_path = args.output
+    os.makedirs(os.path.dirname(os.path.abspath(output_path)), exist_ok=True)
+    with open(output_path, 'w') as f:
+        json.dump(dataset, f, indent=4, sort_keys=True)
+
+    logger.info(f"Updated dataset saved to {output_path}")
+    logger.info(f"  numTraining : {dataset['numTraining']}")
+    logger.info(f"  numTest     : {dataset['numTest']}")
+    if 'numValidation' in dataset:
+        logger.info(f"  numValidation: {dataset['numValidation']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/nnunet/convert_reorient_with_wmn_data.py
+++ b/nnunet/convert_reorient_with_wmn_data.py
@@ -14,6 +14,8 @@ import shutil
 import argparse
 from pathlib import Path
 import nibabel as nib
+import json
+from tqdm import tqdm
 
 
 def parse_args():
@@ -38,20 +40,38 @@ def main():
     list_derivatives = list(Path(wmn_data).rglob("*label-lesion_seg.nii.gz"))
     list_derivatives = [str(path) for path in list_derivatives]
 
-    print(f"Found {len(list_derivatives)} WMn images in the WMn dataset")
+    # Get all WMn images
+    list_images = list(Path(wmn_data).rglob("*WMn.nii.gz"))
+    list_images = [str(path) for path in list_images]
+
+    image_pairs = {}
+    # For each image we keep only the derivative with the highest rater number (e.g. desc-rater4_label-lesion_seg.nii.gz should be kept over desc-rater1_label-lesion_seg.nii.gz)
+    for image in tqdm(list_images):
+        image_name = image.split('/')[-1].replace(".nii.gz", "")
+        corresponding_derivative = [derivative for derivative in list_derivatives if image_name in derivative]
+        # Only the derivative with the highest rater number should be kept (e.g. desc-rater4_label-lesion_seg.nii.gz should be kept over desc-rater1_label-lesion_seg.nii.gz)
+        derivatives_to_remove = sorted(corresponding_derivative, key=lambda x: int(x.split('rater')[1].split('_')[0]), reverse=True)
+        image_pairs[image] = derivatives_to_remove[0]
+
+    # Remove variable list_derivatives
+    del list_derivatives
+    del list_images
+
+    print(f"Found {len(image_pairs)} WMn images in the WMn dataset")
 
     # remove images where sub-XXX greater or equal to 099
     if not args.with_hc:
-        list_derivatives = [path for path in list_derivatives if int(path.split('/')[-1].split('_')[0].replace("sub-", "")) < 99]
-
-    print(f"Found {len(list_derivatives)} WMn images to convert and add to nnUNet dataset")
+        image_pairs = {image: derivative for image, derivative in image_pairs.items() if int(image.split('/')[-1].split('_')[0].split('sub-')[1]) < 99}
+        
+    print(f"Found {len(image_pairs)} WMn images to convert and add to nnUNet dataset")
+    
     # Initialize values of each data split
     count_Tr = 3926
     count_Ts = 433
 
     list_subjects = []
-    for path in list_derivatives:
-        subject_id = path.split('/')[-1].split('_')[0]
+    for sub in image_pairs.keys():
+        subject_id = sub.split('/')[-1].split('_')[0]
         list_subjects.append(subject_id)
 
     # Split the subjects into train and test sets 85/15
@@ -60,6 +80,14 @@ def main():
 
     # Load the conversion dict in the existing nnUNet dataset if it exists, otherwise create an empty dict
     conversion_dict_path = os.path.join(nnunet_data, "conversion_dict.json")
+    # Load the conversion dict
+    with open(conversion_dict_path, "r") as f:
+        conversion_dict = json.load(f)
+
+    # Load the dataset.json file in the existing nnUNet dataset
+    dataset_json_path = os.path.join(nnunet_data, "dataset.json")
+    with open(dataset_json_path, "r") as f:
+        dataset_json = json.load(f)
 
     # Build output folders
     path_out_imagesTr = os.path.join(nnunet_data, 'imagesTr')
@@ -72,11 +100,12 @@ def main():
     os.makedirs(path_out_labelsTs, exist_ok=True)
 
     # Iterate over the derivatives and move them to the nnunet dataset
-    for seg_file in list_derivatives:
-        subject_id = seg_file.split('/')[-1].split('_')[0]
-        print(f"Processing subject {subject_id} with path {seg_file}")
-        # Find corresponding image file
-        image_file = seg_file.replace("_label-lesion_seg.nii.gz", ".nii.gz").replace("derivatives/labels/", "")
+    for image_file in tqdm(image_pairs):
+        subject_id = image_file.split('/')[-1].split('_')[0]
+        print(f"Processing subject {subject_id} with path {image_file}")
+        # Find corresponding seg file
+        seg_file = image_pairs[image_file]
+    
         if subject_id in list_subjects_train:
             count_Tr +=1
             image_file_nnunet = os.path.join(path_out_imagesTr,f'Dataset903_msLesionAgnostic_{count_Tr:03d}_0000.nii.gz')
@@ -93,30 +122,71 @@ def main():
             # Then we reorient the label to RPI
             assert os.system(f"sct_image -i {label_file_nnunet} -setorient RPI -o {label_file_nnunet}") ==0
 
+            # For each label fils, we reorient them to the same orientation as the image using sct_register_multimodal -identity 1
+            assert os.system(f"sct_register_multimodal -i {str(label_file_nnunet)} -d {str(image_file_nnunet)} -identity 1 -o {str(label_file_nnunet)} -owarp file_to_delete.nii.gz -owarpinv file_to_delete_2.nii.gz ") ==0
+            # Remove the other useless files
+            assert os.system("rm file_to_delete.nii.gz file_to_delete_2.nii.gz") ==0
+            other_file_to_remove = str(label_file_nnunet).replace('.nii.gz', '_inv.nii.gz')
+            assert os.system(f"rm {other_file_to_remove}") ==0
+
+            # Then we binarize the label
+            assert os.system(f"sct_maths -i {str(label_file_nnunet)} -bin 0.5 -o {str(label_file_nnunet)}") ==0
+
+            # Add the file to the dataset.json file
+            dataset_json['training'].append({
+                "image": image_file_nnunet,
+                "label": label_file_nnunet
+            })
+
+        else:
+            count_Ts +=1
+            image_file_nnunet = os.path.join(path_out_imagesTs,f'Dataset903_msLesionAgnostic_{count_Ts:03d}_0000.nii.gz')
+            label_file_nnunet = os.path.join(path_out_labelsTs,f'Dataset903_msLesionAgnostic_{count_Ts:03d}.nii.gz')
+
+            # Reorient the image
+            assert os.system(f"sct_image -i {image_file} -setorient RPI -o {image_file_nnunet}") ==0
+
+            # Binarize the label and save it to the adequate path
+            label = nib.load(seg_file).get_fdata()
+            label[label > 0] = 1
+            label = nib.Nifti1Image(label, nib.load(seg_file).affine)
+            nib.save(label, label_file_nnunet)
+            # Then we reorient the label to RPI
+            assert os.system(f"sct_image -i {label_file_nnunet} -setorient RPI -o {label_file_nnunet}") ==0
+
+            # For each label fils, we reorient them to the same orientation as the image using sct_register_multimodal -identity 1
+            assert os.system(f"sct_register_multimodal -i {str(label_file_nnunet)} -d {str(image_file_nnunet)} -identity 1 -o {str(label_file_nnunet)} -owarp file_to_delete.nii.gz -owarpinv file_to_delete_2.nii.gz ") ==0
+            # Remove the other useless files
+            assert os.system("rm file_to_delete.nii.gz file_to_delete_2.nii.gz") ==0
+            other_file_to_remove = str(label_file_nnunet).replace('.nii.gz', '_inv.nii.gz')
+            assert os.system(f"rm {other_file_to_remove}") ==0
+
+            # Then we binarize the label
+            assert os.system(f"sct_maths -i {str(label_file_nnunet)} -bin 0.5 -o {str(label_file_nnunet)}") ==0
+
+             # Add the file to the dataset.json file
+            dataset_json['test'].append({
+                "image": image_file_nnunet,
+                "label": label_file_nnunet
+            })
+
         # Update the conversion dict
-        conversion_dict[str(os.path.abspath(img_dict['image']))] = image_file_nnunet
-        conversion_dict[str(os.path.abspath(img_dict['label']))] = label_file_nnunet
+        conversion_dict[image_file] = image_file_nnunet
+        conversion_dict[seg_file] = label_file_nnunet
+    
+    # Update the dataset.json files count values
+    dataset_json['numTraining'] = count_Tr
+    dataset_json['numTest'] = count_Ts
 
-        # For each label fils, we reorient them to the same orientation as the image using sct_register_multimodal -identity 1
-        assert os.system(f"sct_register_multimodal -i {str(label_file_nnunet)} -d {str(image_file_nnunet)} -identity 1 -o {str(label_file_nnunet)} -owarp file_to_delete.nii.gz -owarpinv file_to_delete_2.nii.gz ") ==0
-        # Remove the other useless files
-        assert os.system("rm file_to_delete.nii.gz file_to_delete_2.nii.gz") ==0
-        other_file_to_remove = str(label_file_nnunet).replace('.nii.gz', '_inv.nii.gz')
-        assert os.system(f"rm {other_file_to_remove}") ==0
+    # Save the updated dataset.json file
+    with open(dataset_json_path, "w") as f:
+        json.dump(dataset_json, f, indent=4)
 
-        # Then we binarize the label
-        assert os.system(f"sct_maths -i {str(label_file_nnunet)} -bin 0.5 -o {str(label_file_nnunet)}") ==0
+    # Save the updated conversion dict
+    with open(conversion_dict_path, "w") as f:
+        json.dump(conversion_dict, f, indent=4)
 
-        break
-
-    # TODO: do the same for the test set and test the above (issue with the conversion dict)
-
-            
-        # elif subject_id in list_subjects_test:
-
-    # 
-
-
+    return None
 
     
 if __name__ == "__main__":

--- a/nnunet/convert_reorient_with_wmn_data.py
+++ b/nnunet/convert_reorient_with_wmn_data.py
@@ -1,0 +1,123 @@
+"""
+This script is used to convert the WMn data to the nnUNet format and add them to the an existing dataset. 
+This way we avoid having to re-convert all 4000 images and only haev to do it with WMn images.
+
+Input:
+    -nnnunet-data: Path to existing nnUNet dataset where the data will be copied (e.g. nnUNet_raw/TaskXXX_MyDataset)
+    -wmn-data: Path to WMn data
+    -with-hc: Whether to include healthy controls in the dataset (default: False)
+
+Author: Pierre-Louis Benveniste
+"""
+import os
+import shutil
+import argparse
+from pathlib import Path
+import nibabel as nib
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Convert WMn data to nnUNet format and add to existing dataset")
+    parser.add_argument("--nnunet-data", type=str, required=True, help="Path to existing nnUNet dataset (e.g. nnUNet_raw/TaskXXX_MyDataset)")
+    parser.add_argument("--wmn-data", type=str, required=True, help="Path to WMn data")
+    parser.add_argument("--with-hc", action="store_true", help="Whether to include healthy controls in the dataset (default: False)")
+    return parser.parse_args()
+
+
+def main():
+
+    # Parse arguments
+    args = parse_args()
+    nnunet_data = args.nnunet_data
+    wmn_data = args.wmn_data
+
+    # If the output directory does not exist, create it
+    os.makedirs(nnunet_data, exist_ok=True)
+
+    # Get all files from WMn data
+    list_derivatives = list(Path(wmn_data).rglob("*label-lesion_seg.nii.gz"))
+    list_derivatives = [str(path) for path in list_derivatives]
+
+    print(f"Found {len(list_derivatives)} WMn images in the WMn dataset")
+
+    # remove images where sub-XXX greater or equal to 099
+    if not args.with_hc:
+        list_derivatives = [path for path in list_derivatives if int(path.split('/')[-1].split('_')[0].replace("sub-", "")) < 99]
+
+    print(f"Found {len(list_derivatives)} WMn images to convert and add to nnUNet dataset")
+    # Initialize values of each data split
+    count_Tr = 3926
+    count_Ts = 433
+
+    list_subjects = []
+    for path in list_derivatives:
+        subject_id = path.split('/')[-1].split('_')[0]
+        list_subjects.append(subject_id)
+
+    # Split the subjects into train and test sets 85/15
+    list_subjects_train = list_subjects[:int(0.85 * len(list_subjects))]
+    list_subjects_test = list_subjects[int(0.85 * len(list_subjects)):]
+
+    # Load the conversion dict in the existing nnUNet dataset if it exists, otherwise create an empty dict
+    conversion_dict_path = os.path.join(nnunet_data, "conversion_dict.json")
+
+    # Build output folders
+    path_out_imagesTr = os.path.join(nnunet_data, 'imagesTr')
+    path_out_labelsTr = os.path.join(nnunet_data, 'labelsTr')
+    path_out_imagesTs = os.path.join(nnunet_data, 'imagesTs')
+    path_out_labelsTs = os.path.join(nnunet_data, 'labelsTs')
+    os.makedirs(path_out_imagesTr, exist_ok=True)
+    os.makedirs(path_out_labelsTr, exist_ok=True)
+    os.makedirs(path_out_imagesTs, exist_ok=True)
+    os.makedirs(path_out_labelsTs, exist_ok=True)
+
+    # Iterate over the derivatives and move them to the nnunet dataset
+    for seg_file in list_derivatives:
+        subject_id = seg_file.split('/')[-1].split('_')[0]
+        print(f"Processing subject {subject_id} with path {seg_file}")
+        # Find corresponding image file
+        image_file = seg_file.replace("_label-lesion_seg.nii.gz", ".nii.gz").replace("derivatives/labels/", "")
+        if subject_id in list_subjects_train:
+            count_Tr +=1
+            image_file_nnunet = os.path.join(path_out_imagesTr,f'Dataset903_msLesionAgnostic_{count_Tr:03d}_0000.nii.gz')
+            label_file_nnunet = os.path.join(path_out_labelsTr,f'Dataset903_msLesionAgnostic_{count_Tr:03d}.nii.gz')
+
+            # Reorient the image
+            assert os.system(f"sct_image -i {image_file} -setorient RPI -o {image_file_nnunet}") ==0
+
+            # Binarize the label and save it to the adequate path
+            label = nib.load(seg_file).get_fdata()
+            label[label > 0] = 1
+            label = nib.Nifti1Image(label, nib.load(seg_file).affine)
+            nib.save(label, label_file_nnunet)
+            # Then we reorient the label to RPI
+            assert os.system(f"sct_image -i {label_file_nnunet} -setorient RPI -o {label_file_nnunet}") ==0
+
+        # Update the conversion dict
+        conversion_dict[str(os.path.abspath(img_dict['image']))] = image_file_nnunet
+        conversion_dict[str(os.path.abspath(img_dict['label']))] = label_file_nnunet
+
+        # For each label fils, we reorient them to the same orientation as the image using sct_register_multimodal -identity 1
+        assert os.system(f"sct_register_multimodal -i {str(label_file_nnunet)} -d {str(image_file_nnunet)} -identity 1 -o {str(label_file_nnunet)} -owarp file_to_delete.nii.gz -owarpinv file_to_delete_2.nii.gz ") ==0
+        # Remove the other useless files
+        assert os.system("rm file_to_delete.nii.gz file_to_delete_2.nii.gz") ==0
+        other_file_to_remove = str(label_file_nnunet).replace('.nii.gz', '_inv.nii.gz')
+        assert os.system(f"rm {other_file_to_remove}") ==0
+
+        # Then we binarize the label
+        assert os.system(f"sct_maths -i {str(label_file_nnunet)} -bin 0.5 -o {str(label_file_nnunet)}") ==0
+
+        break
+
+    # TODO: do the same for the test set and test the above (issue with the conversion dict)
+
+            
+        # elif subject_id in list_subjects_test:
+
+    # 
+
+
+
+    
+if __name__ == "__main__":
+    main()

--- a/nnunet/convert_reorient_with_wmn_data.py
+++ b/nnunet/convert_reorient_with_wmn_data.py
@@ -108,8 +108,8 @@ def main():
     
         if subject_id in list_subjects_train:
             count_Tr +=1
-            image_file_nnunet = os.path.join(path_out_imagesTr,f'Dataset903_msLesionAgnostic_{count_Tr:03d}_0000.nii.gz')
-            label_file_nnunet = os.path.join(path_out_labelsTr,f'Dataset903_msLesionAgnostic_{count_Tr:03d}.nii.gz')
+            image_file_nnunet = os.path.join(path_out_imagesTr,f'msLesionAgnostic_{count_Tr:03d}_0000.nii.gz')
+            label_file_nnunet = os.path.join(path_out_labelsTr,f'msLesionAgnostic_{count_Tr:03d}.nii.gz')
 
             # Reorient the image
             assert os.system(f"sct_image -i {image_file} -setorient RPI -o {image_file_nnunet}") ==0
@@ -140,8 +140,8 @@ def main():
 
         else:
             count_Ts +=1
-            image_file_nnunet = os.path.join(path_out_imagesTs,f'Dataset903_msLesionAgnostic_{count_Ts:03d}_0000.nii.gz')
-            label_file_nnunet = os.path.join(path_out_labelsTs,f'Dataset903_msLesionAgnostic_{count_Ts:03d}.nii.gz')
+            image_file_nnunet = os.path.join(path_out_imagesTs,f'msLesionAgnostic_{count_Ts:03d}_0000.nii.gz')
+            label_file_nnunet = os.path.join(path_out_labelsTs,f'msLesionAgnostic_{count_Ts:03d}.nii.gz')
 
             # Reorient the image
             assert os.system(f"sct_image -i {image_file} -setorient RPI -o {image_file_nnunet}") ==0


### PR DESCRIPTION
This pull request introduces two new scripts to support the integration of WMn data into existing nnUNet and MSD-style datasets. The scripts automate the conversion, metadata extraction, and dataset augmentation processes for WMn images and labels, ensuring consistency and reducing manual effort.

**WMn Data Integration and Conversion:**

* Adds a script (`add_wnn_data_to_existing_msd.py`) to append WMn data entries to an existing MSD-style dataset JSON. This script reads image/label pairs from a conversion dictionary, extracts relevant metadata (contrast, site, acquisition, resolution, dimension, lesion counts), and updates the dataset splits and statistics accordingly.
* Introduces a script (`convert_reorient_with_wmn_data.py`) to convert WMn data to nnUNet format and add them to an existing nnUNet dataset. The script handles image/label pairing, reorientation, binarization, split assignment, and updates both the `dataset.json` and the conversion dictionary.
