### PR TITLE
Adding lesion_ms model citation in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ sct_deepseg lesion_ms
 
 More details can be found in the user section [here](https://spinalcordtoolbox.com/stable/user_section/command-line/sct_deepseg.html#sct-deepseg)
 
+### Code repository
+
 <details>
 <summary><b>Code description</b></summary>
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Robust Spinal Cord MS Lesion Segmentation Across Diverse MRI Protocols and Centers
 
-TODO: when published: add icon similar to this one (https://github.com/sct-pipeline/contrast-agnostic-softseg-spinalcord/blob/bfcb8352aa2cdbcb356e428181fbc3dbd2fa42ef/README.md?plain=1#L3)
+[![MSJ](https://img.shields.io/badge/MSJ-10.1177/13524585261427333-darkgreen.svg)](https://doi.org/10.1177/13524585261427333)
 
 <img src="https://github.com/user-attachments/assets/6c86548a-0a28-40e4-9d21-219ac310d867" width="500"/>
 
@@ -15,7 +15,19 @@ This repo contains all the code for training the SC MS lesion segmentation model
 If you find this work and/or code useful for your research, please cite our paper:
 
 ```
-TODO: when published, add citation.
+@article{doi:10.1177/13524585261427333,
+title ={Generalizable spinal cord multiple sclerosis lesion segmentation across MRI contrasts, protocols, and centers},
+journal = {Multiple Sclerosis Journal},
+volume = {0},
+number = {0},
+pages = {13524585261427333},
+year = {2026},
+doi = {10.1177/13524585261427333},
+note ={PMID: 42028790},
+URL = {https://doi.org/10.1177/13524585261427333},
+eprint = {https://doi.org/10.1177/13524585261427333}
+author = {Pierre-Louis Benveniste and Laurent Létourneau-Guillon and David Araujo and Lydia Chougar and Dumitru Fetco and Masaaki Hori and Kouhei Kamiya and Steven Messina and Charidimos Tsagkas and Bertrand Audoin and Rohit Bakshi and Elise Bannier and Daniel Blezek and Jean-Christophe Brisset and Virginie Callot and Erik Charlson and Michelle Chen and Olga Ciccarelli and Sarah Demortière and Gilles Edan and Massimo Filippi and Tobias Granberg and Cristina Granziera and Christopher C. Hemond and B. Mark Keegan and Anne Kerbrat and Jan Kirschke and Shannon Kolind and Pierre Labauge and Lisa Eunyoung Lee and Yaou Liu and Caterina Mainero and Julian McGinnis and Nilser Laines Medina and Mark Mühlau and Govind Nair and Kristin P. O’Grady and Jiwon Oh and Russell Ouellette and Alexandre Prat and Daniel S. Reich and Maria A. Rocca and Timothy M. Shepherd and Seth A. Smith and Leszek Stawiarz and Jason Talbott and Roger Tam and Shahamat Tauhid and Anthony Traboulsee and Constantina Andrada Treaba and Paola Valsasina and Zachary Vavasour and Marios Yiannakas and Hervé Lombaert and Julien Cohen-Adad}
+}
 ```
 
 ### How to use the model
@@ -29,20 +41,8 @@ sct_deepseg lesion_ms
 
 More details can be found in the user section [here](https://spinalcordtoolbox.com/stable/user_section/command-line/sct_deepseg.html#sct-deepseg)
 
-### Annotators
-
-Below is a list of certified radiologists who have helped label lesion segmentation.
-
-- Laurent Létourneau-Guillon
-- David Araujo
-- Lydia Chougar
-- Dumitru Fetco
-- Masaaki Hori
-- Kouhei Kamiya
-- Steven Messina
-- Charidimos Tsagkas
-
-### Code description
+<details>
+<summary><b>Code description</b></summary>
 
 The repository contains all the code for the SC MS lesion segmentation project:
 - `compute_canada_scripts`: code used to train the model on compute canada
@@ -51,6 +51,7 @@ The repository contains all the code for the SC MS lesion segmentation project:
 - `evaluation`: code used to evaluate the performance of the model
 - `nnunet`: code used for training with nnunet
 - `post-processing`: code used for post-processing
+</details>
 
 ## Longitudinal tracking of multiple sclerosis lesions in the spinal cord: A validation study
 


### PR DESCRIPTION
This pull request updates the `README.md` to reflect the recent publication of the spinal cord MS lesion segmentation paper and improves the organization and presentation of project information. The most important changes are:

Publication and citation updates:
* Added a badge with a link to the published article on the MSJ website at the top of the README.
* Replaced the placeholder citation with the full bibliographic entry for the published paper, including DOI, title, authors, and other metadata.

README organization improvements:
* Removed the "Annotators" section listing radiologists who helped with lesion segmentation.
* Collapsed the code description into a `<details>` block to improve readability and organization of the README. 